### PR TITLE
Adds has_interrupt to FdCan and FdCanControl.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,12 @@ where
         }
     }
 
+    /// Check if the interrupt is triggered
+    #[inline]
+    pub fn has_interrupt(&mut self, interrupt: Interrupt) -> bool {
+        self.control.has_interrupt(interrupt)
+    }
+
     /// Clear specified interrupt
     #[inline]
     pub fn clear_interrupt(&mut self, interrupt: Interrupt) {
@@ -1133,6 +1139,13 @@ where
     #[inline]
     pub fn timestamp(&self) -> u16 {
         self.registers().tscv.read().tsc().bits()
+    }
+
+    /// Check if the interrupt is triggered
+    #[inline]
+    pub fn has_interrupt(&mut self, interrupt: Interrupt) -> bool {
+        let can = self.registers();
+        can.ir.read().bits() & (interrupt as u32) > 0
     }
 
     /// Clear specified interrupt


### PR DESCRIPTION
This adds a function called has_interrupt to both FdCan and FdCanControl.

Necessary when inside an interrupt and seeking to know what caused it.