### PR TITLE
IdReg: Correctly use a mask when creating an Id with to_id()

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -213,11 +213,15 @@ impl IdReg {
     pub fn to_id(self) -> Id {
         if self.is_extended() {
             Id::Extended(unsafe {
-                ExtendedId::new_unchecked(self.0 >> Self::EXTENDED_SHIFT)
+                ExtendedId::new_unchecked(
+                    (self.0 >> Self::EXTENDED_SHIFT) & Self::EXTENDED_MASK,
+                )
             })
         } else {
             Id::Standard(unsafe {
-                StandardId::new_unchecked((self.0 >> Self::STANDARD_SHIFT) as u16)
+                StandardId::new_unchecked(
+                    ((self.0 >> Self::STANDARD_SHIFT) & Self::STANDARD_MASK) as u16,
+                )
             })
         }
     }

--- a/src/id.rs
+++ b/src/id.rs
@@ -152,7 +152,6 @@ pub(crate) struct IdReg(u32);
 
 impl IdReg {
     const STANDARD_SHIFT: u32 = 18;
-    #[allow(dead_code)]
     const STANDARD_MASK: u32 = 0x1FFC0000;
 
     const EXTENDED_SHIFT: u32 = 0;


### PR DESCRIPTION
Fixes a problem where the Extended bit was added to the ExtendedId.