### PR TITLE
Updates for H7 and MP1 families

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ fdcan_h7 = []                   # Peripheral map found on H7
 
 [dependencies]
 bitflags = "1.3.2"
+paste = "1.0"
 vcell = "0.1.3"
 nb = "1.0.0"
 static_assertions = "1.1"

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -5,147 +5,169 @@ use core::ops;
 #[allow(unused_imports)] // for intra-doc links only
 use crate::{FdCan, Rx};
 
-/// FdCAN interrupt sources.
-///
-/// These can be individually enabled and disabled in the FdCAN peripheral. Note that each FdCAN
-/// peripheral only exposes 2 interrupts to the microcontroller:
-///
-/// FDCANx_INTR0,
-/// FDCANx_INTR1,
-///
-/// The interrupts available on each line can be configured using the [`crate::config::FdCanConfig`] struct.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-#[non_exhaustive]
-pub enum Interrupt {
-    /// Rx FIFO 0 has a new message
-    RxFifo0NewMsg = 1 << 0,
-    /// Rx FIFO 0 is full
-    RxFifo0Full = 1 << 1,
-    /// Rx FIFO 0 has lost a message
-    RxFifo0MsgLost = 1 << 2,
-    /// Rx FIFO 1 has a new message
-    RxFifo1NewMsg = 1 << 3,
-    /// Rx FIFO 1 is full
-    RxFifo1Full = 1 << 4,
-    /// Rx FIFO 1 has lost a message
-    RxFifo1MsgLost = 1 << 5,
-    /// A High Priority Message has been flagged by a filter
-    RxHighPrio = 1 << 6,
-    /// Transmit has been completed
-    TxComplete = 1 << 7,
-    /// Tx message has been cancelled
-    TxCancel = 1 << 8,
-    /// Tx Fifo is empty
-    TxEmpty = 1 << 9,
-    /// An new Event has been received in the Tx Event Fifo
-    TxEventNew = 1 << 10,
-    /// The TxEvent Fifo is full
-    TxEventFull = 1 << 11,
-    /// An Tx Event has been lost
-    TxEventLost = 1 << 12,
-    /// Timestamp wrap around has occurred
-    TsWrapAround = 1 << 13,
-    /// Message RAM access failure
-    ///
-    /// The flag is set when the Rx handler:
-    /// has not completed acceptance filtering or storage of an accepted message until the
-    /// arbitration field of the following message has been received. In this case acceptance
-    /// filtering or message storage is aborted and the Rx handler starts processing of the
-    /// following message. was unable to write a message to the message RAM. In this case
-    /// message storage is aborted.
-    /// In both cases the FIFO put index is not updated. The partly stored message is overwritten
-    /// when the next message is stored to this location.
-    /// The flag is also set when the Tx Handler was not able to read a message from the Message
-    /// RAM in time. In this case message transmission is aborted. In case of a Tx Handler access
-    /// failure the FDCAN is switched into Restricted operation Mode (see Restricted operation
-    /// mode).
-    MsgRamAccessFailure = 1 << 14,
-    /// Timeout Occurred
-    TimeoutOccurred = 1 << 15,
-    /// Overflow of CAN error logging counter occurred
-    ErrLogOverflow = 1 << 16,
-    /// Errr Passive
-    ErrPassive = 1 << 17,
-    /// Warning Status
-    WarningStatus = 1 << 18,
-    /// Bus_Off status
-    BusOff = 1 << 19,
-    ///  Watchdog interrupt
-    WatchdogInt = 1 << 20,
-    /// Protocol error in arbitration phase (nominal bit time is used)
-    ProtErrArbritation = 1 << 21,
-    /// Protocol error in data phase (data bit time is used)
-    ProtErrData = 1 << 22,
-    /// Access to reserved address
-    ReservedAccess = 1 << 23,
+macro_rules! declare_interrupts {
+    ($([$name:ident, $index:literal, $doc:expr],)*) => {
+        /// FdCAN interrupt sources.
+        ///
+        /// These can be individually enabled and disabled in the FdCAN
+        /// peripheral. Note that each FdCAN peripheral only exposes 2
+        /// interrupts to the microcontroller:
+        ///
+        /// FDCANx_INTR0,
+        /// FDCANx_INTR1,
+        ///
+        /// The interrupts available on each line can be configured using the
+        /// [`crate::config::FdCanConfig`] struct.
+        #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+        #[non_exhaustive]
+        pub enum Interrupt {
+            $(
+                #[doc = $doc]
+                $name = 1 << $index
+            ),*
+        }
+
+        paste::paste! {
+            bitflags::bitflags! {
+                /// A set of FdCAN interrupts.
+                pub struct Interrupts: u32 {
+                    $(
+                        #[doc = $doc]
+                        const [< $name:snake:upper >] = 1 << $index;
+                    )*
+                }
+            }
+        }
+    };
 }
 
-bitflags::bitflags! {
-    /// A set of FdCAN interrupts.
-    pub struct Interrupts: u32 {
-        /// Rx FIFO 0 has a new message
-        const RX_FIFO_0_NEW_MESSAGE = 1 << 0;
-        /// Rx FIFO 0 is full
-        const RX_FIFO_0_FULL = 1 << 1;
-        /// Rx FIFO 0 has lost a message
-        const RX_FIFO_0_MSG_LOST = 1 << 2;
-        /// Rx FIFO 1 has a new message
-        const RX_FIFO_1_NEW_MESSAGE = 1 << 3;
-        /// Rx FIFO 1 is full
-        const RX_FIFO_1_FULL = 1 << 4;
-        /// Rx FIFO 1 has lost a message
-        const RX_FIFO_1_MSG_LOST = 1 << 5;
-        /// A High Priority Message has been flagged by a filter
-        const RX_HIGH_PRIO_MSG = 1<<6;
-        /// Transmit has been completed
-        const TX_COMPLETE = 1<<7;
-        /// Tx message has been cancelled
-        const TX_CANCEL = 1<<8;
-        /// Tx Fifo is empty
-        const TX_EMPTY = 1<<9;
-        /// An new Event has been received in the Tx Event Fifo
-        const TX_EVENT_NEW = 1<<10;
-        /// The TxEvent Fifo is full
-        const TX_EVENT_FULL = 1<<11;
-        /// An Tx Event has been lost
-        const TX_EVENT_LOST = 1<<12;
-        /// Timestamp wrap around has occurred
-        const TS_WRAP_AROUND = 1<<13;
-        /// Message RAM access failure
-        ///
-        /// The flag is set when the Rx handler:
-        /// has not completed acceptance filtering or storage of an accepted message until the
-        /// arbitration field of the following message has been received. In this case acceptance
-        /// filtering or message storage is aborted and the Rx handler starts processing of the
-        /// following message. was unable to write a message to the message RAM. In this case
-        /// message storage is aborted.
-        /// In both cases the FIFO put index is not updated. The partly stored message is overwritten
-        /// when the next message is stored to this location.
-        /// The flag is also set when the Tx Handler was not able to read a message from the Message
-        /// RAM in time. In this case message transmission is aborted. In case of a Tx Handler access
-        /// failure the FDCAN is switched into Restricted operation Mode (see Restricted operation
-        /// mode).
-        const MSG_RAM_ACCESS_FAILURE = 1<<14;
-        /// Timeout Occurred
-        const TIMEOUT_OCCURRED = 1<<15;
-        /// Overflow of CAN error logging counter occurred
-        const ERR_LOG_OVERFLOW = 1<<16;
-        /// Err Passive
-        const ERR_PASSIVE = 1<<17;
-        /// Warning Status
-        const WARNING_STATUS = 1<<18;
-        /// Bus_Off status
-        const BUS_OFF = 1<<19;
-        ///  Watchdog interrupt
-        const WATCHDOG_INT = 1<<20;
-        /// Protocol error in arbitration phase (nominal bit time is used)
-        const PROT_ERR_ARBRITATION = 1<<21;
-        /// Protocol error in data phase (data bit time is used)
-        const PROT_ERR_DATA = 1<<22;
-        /// Access to reserved address
-        const RESERVED_ACCESS = 1<<23;
-    }
-}
+// interrupts for g0 g4 l5
+#[cfg(feature = "fdcan_g0_g4_l5")]
+declare_interrupts!(
+    [RxFifo0NewMsg, 0, "Rx FIFO 0 has a new message"],
+    [RxFifo0Full, 1, "Rx FIFO 0 is full"],
+    [RxFifo0MsgLost, 2, "Rx FIFO 0 has lost a message"],
+    [RxFifo1NewMsg, 3, "Rx FIFO 1 has a new message"],
+    [RxFifo1Full, 4, "Rx FIFO 1 is full"],
+    [RxFifo1MsgLost, 5, "Rx FIFO 1 has lost a message"],
+    [
+        RxHighPrio,
+        6,
+        "A High Priority Message has been flagged by a filter"
+    ],
+    [TxComplete, 7, "Transmit has been completed"],
+    [TxCancel, 8, "Tx message has been cancelled"],
+    [TxEmpty, 9, "Tx Fifo is empty"],
+    [
+        TxEventNew,
+        10,
+        "An new Event has been received in the Tx Event Fifo"
+    ],
+    [TxEventFull, 11, "The TxEvent Fifo is full"],
+    [TxEventLost, 12, "An Tx Event has been lost"],
+    [TsWrapAround, 13, "Timestamp wrap around has occurred"],
+    [MsgRamAccessFailure, 14, "Message RAM access failure.
+The flag is set when the Rx handler:
+has not completed acceptance filtering or storage of an accepted message until the
+arbitration field of the following message has been received. In this case acceptance
+filtering or message storage is aborted and the Rx handler starts processing of the
+following message. was unable to write a message to the message RAM. In this case
+message storage is aborted.
+In both cases the FIFO put index is not updated. The partly stored message is overwritten
+when the next message is stored to this location.
+The flag is also set when the Tx Handler was not able to read a message from the Message
+RAM in time. In this case message transmission is aborted. In case of a Tx Handler access
+failure the FDCAN is switched into Restricted operation Mode (see Restricted operation
+mode)."],
+    [TimeoutOccurred, 15, "Timeout Occurred"],
+    [
+        ErrLogOverflow,
+        16,
+        "Overflow of CAN error logging counter occurred"
+    ],
+    [ErrPassive, 17, "Errr Passive"],
+    [WarningStatus, 18, "Warning Status"],
+    [BusOff, 19, "Bus_Off status"],
+    [WatchdogInt, 20, " Watchdog interrupt"],
+    [
+        ProtErrArbritation,
+        21,
+        "Protocol error in arbitration phase (nominal bit time is used)"
+    ],
+    [
+        ProtErrData,
+        22,
+        "Protocol error in data phase (data bit time is used)"
+    ],
+    [ReservedAccess, 23, "Access to reserved address"],
+);
+
+// interrupts for h7
+#[cfg(feature = "fdcan_h7")]
+declare_interrupts!(
+    [RxFifo0NewMsg, 0, "Rx FIFO 0 has a new message"],
+    [RxFifo0Watermark, 1, "Rx FIFO 0 watermark reached"],
+    [RxFifo0Full, 2, "Rx FIFO 0 is full"],
+    [RxFifo0MsgLost, 3, "Rx FIFO 0 has lost a message"],
+
+    [RxFifo1NewMsg, 4, "Rx FIFO 1 has a new message"],
+    [RxFifo1Watermark, 5, "Rx FIFO 1 watermark reached"],
+    [RxFifo1Full, 6, "Rx FIFO 1 is full"],
+    [RxFifo1MsgLost, 7, "Rx FIFO 1 has lost a message"],
+
+    [
+        RxHighPrio,
+        8,
+        "A High Priority Message has been flagged by a filter"
+    ],
+    [TxComplete, 9, "Transmit has been completed"],
+    [TxCancel, 10, "Tx message has been cancelled"],
+    [TxEmpty, 11, "Tx Fifo is empty"],
+    [
+        TxEventNew,
+        12,
+        "An new Event has been received in the Tx Event Fifo"
+    ],
+    [TxWatermark, 13, "TxEvent FIFO watermark reached"],
+    [TxEventFull, 14, "The TxEvent Fifo is full"],
+    [TxEventLost, 15, "An Tx Event has been lost"],
+    [TsWrapAround, 16, "Timestamp wrap around has occurred"],
+
+    [MsgRamAccessFailure, 17, "Message RAM access failure.
+The flag is set when the Rx handler:
+has not completed acceptance filtering or storage of an accepted message until the
+arbitration field of the following message has been received. In this case acceptance
+filtering or message storage is aborted and the Rx handler starts processing of the
+following message. was unable to write a message to the message RAM. In this case
+message storage is aborted.
+In both cases the FIFO put index is not updated. The partly stored message is overwritten
+when the next message is stored to this location.
+The flag is also set when the Tx Handler was not able to read a message from the Message
+RAM in time. In this case message transmission is aborted. In case of a Tx Handler access
+failure the FDCAN is switched into Restricted operation Mode (see Restricted operation
+mode)."],
+    [TimeoutOccurred, 18, "Timeout Occurred"],
+    [
+        ErrLogOverflow,
+        22,
+        "Overflow of CAN error logging counter occurred"
+    ],
+    [ErrPassive, 23, "Errr Passive"],
+    [WarningStatus, 24, "Warning Status"],
+    [BusOff, 25, "Bus_Off status"],
+    [WatchdogInt, 26, " Watchdog interrupt"],
+    [
+        ProtErrArbritation,
+        27,
+        "Protocol error in arbitration phase (nominal bit time is used)"
+    ],
+    [
+        ProtErrData,
+        28,
+        "Protocol error in data phase (data bit time is used)"
+    ],
+    [ReservedAccess, 29, "Access to reserved address"],
+);
 
 impl Interrupts {
     /// No Interrupt masks selected
@@ -192,11 +214,8 @@ mod tests {
         );
         assert_eq!(Interrupts::from(Interrupt::TxEmpty), Interrupts::TX_EMPTY);
 
-        let mut ints = Interrupts::RX_FIFO_0_FULL;
+        let mut ints = Interrupts::RX_FIFO0_FULL;
         ints |= Interrupt::RxFifo1Full;
-        assert_eq!(
-            ints,
-            Interrupts::RX_FIFO_0_FULL | Interrupts::RX_FIFO_1_FULL
-        );
+        assert_eq!(ints, Interrupts::RX_FIFO0_FULL | Interrupts::RX_FIFO1_FULL);
     }
 }


### PR DESCRIPTION
Add and re-number interrupts for H7 and MP1 families. Renamed SCREAMING_CASE interrupts that did not match the CamelCase versions

RX_FIFO_0_xxx -> RX_FIFO0_xxx
RX_FIFO_1_xxx -> RX_FIFO1_xxx