### PR TITLE
Use volatile reads and writes for rx and tx buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ paste = "1.0"
 vcell = "0.1.3"
 nb = "1.0.0"
 static_assertions = "1.1"
+volatile-register = "0.2.1"
 
 [dependencies.embedded-can-03]
 version = "0.3"

--- a/src/message_ram.rs
+++ b/src/message_ram.rs
@@ -1,3 +1,5 @@
+use volatile_register::RW;
+
 pub(crate) mod common;
 pub(crate) mod enums;
 pub(crate) mod generic;
@@ -100,12 +102,14 @@ pub(crate) mod rxfifo_element;
 #[repr(C)]
 pub(crate) struct RxFifoElement {
     pub(crate) header: RxFifoElementHeader,
-    pub(crate) data: [u32; 16], // TODO: Does this need to be volatile?
+    pub(crate) data: [RW<u32>; 16],
 }
 impl RxFifoElement {
     pub(crate) fn reset(&mut self) {
         self.header.reset();
-        self.data = [0; 16];
+        for byte in self.data.iter_mut() {
+            unsafe { byte.write(0) };
+        }
     }
 }
 pub(crate) type RxFifoElementHeaderType = [u32; 2];
@@ -119,12 +123,14 @@ pub(crate) mod txbuffer_element;
 #[repr(C)]
 pub(crate) struct TxBufferElement {
     pub(crate) header: TxBufferElementHeader,
-    pub(crate) data: [u32; 16], // TODO: Does this need to be volatile?
+    pub(crate) data: [RW<u32>; 16],
 }
 impl TxBufferElement {
     pub(crate) fn reset(&mut self) {
         self.header.reset();
-        self.data = [0; 16];
+        for byte in self.data.iter_mut() {
+            unsafe { byte.write(0) };
+        }
     }
 }
 pub(crate) type TxBufferElementHeader =


### PR DESCRIPTION
Hi, I'm using this library to drive FDCAN on an Stm32H7 microprocessor and I was able to send CAN messages with the correct header and id, but all data bytes were transmitted as zero bytes.

Looking into it, it appears that the ready to transmit bit (`txbar`) is set before the bytes are actually written to the transmit buffer.
There was already a todo at the transmit buffer hinting at this problem, and indeed using volatile writes fixes the problem for me.

I decided to also wrap the rx buffer in a volatile container, just to be safe, even though that receiving seems to also work without it.

I used the `volatile-register` crate, because it is also used by the `cortex-m` crate.