### PR TITLE
Fix transmit pause configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,7 +765,7 @@ where
     #[inline]
     pub fn set_transmit_pause(&mut self, enabled: bool) {
         let can = self.registers();
-        can.cccr.modify(|_, w| w.dar().bit(!enabled));
+        can.cccr.modify(|_, w| w.txp().bit(enabled));
         self.control.config.transmit_pause = enabled;
     }
 


### PR DESCRIPTION
The DAR (Disable Auto Retransmission) bit was used erroneously. Correctly, the TXP (Transmit Pause) bit should be used. Negation is not necessary, either.