### PR TITLE
Add defmt support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ targets = ["thumbv7em-none-eabihf"]
 fdcan_g0_g4_l5 = []             # Peripheral map found on G0 G4 L5
 fdcan_h7 = []                   # Peripheral map found on H7
 
+defmt-03 = ["dep:defmt"]
+
 [dependencies]
 bitflags = "1.3.2"
 paste = "1.0"
@@ -29,6 +31,7 @@ vcell = "0.1.3"
 nb = "1.0.0"
 static_assertions = "1.1"
 volatile-register = "0.2.1"
+defmt = "0.3.6"
 
 [dependencies.embedded-can-03]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ vcell = "0.1.3"
 nb = "1.0.0"
 static_assertions = "1.1"
 volatile-register = "0.2.1"
-defmt = "0.3.6"
+defmt = { version = "0.3.6", optional = true }
 
 [dependencies.embedded-can-03]
 version = "0.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ use core::num::{NonZeroU16, NonZeroU8};
 /// Then copy the `CAN_BUS_TIME` register value from the table and pass it as the `btr`
 /// parameter to this method.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct NominalBitTiming {
     /// Value by which the oscillator frequency is divided for generating the bit time quanta. The bit
     /// time is built up from a multiple of this quanta. Valid values are 1 to 512.
@@ -61,6 +62,7 @@ impl Default for NominalBitTiming {
 /// Configures the data bit timings for the FdCan Variable Bitrates.
 /// This is not used when frame_transmit is set to anything other than AllowFdCanAndBRS.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct DataBitTiming {
     /// Tranceiver Delay Compensation
     pub transceiver_delay_compensation: bool,
@@ -120,6 +122,7 @@ impl Default for DataBitTiming {
 /// or use Bit rate switching. But if this general setting does not allow
 /// that, only classic CAN is used instead.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum FrameTransmissionConfig {
     /// Only allow Classic CAN message Frames
     ClassicCanOnly,
@@ -131,6 +134,7 @@ pub enum FrameTransmissionConfig {
 
 ///
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum ClockDivider {
     /// Divide by 1
     _1 = 0b0000,
@@ -168,6 +172,7 @@ pub enum ClockDivider {
 
 /// Prescaler of the Timestamp counter
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum TimestampPrescaler {
     /// 1
     _1 = 1,
@@ -205,6 +210,7 @@ pub enum TimestampPrescaler {
 
 /// Selects the source of the Timestamp counter
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum TimestampSource {
     /// The Timestamp counter is disabled
     None,
@@ -217,6 +223,7 @@ pub enum TimestampSource {
 
 /// How to handle frames in the global filter
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum NonMatchingFilter {
     /// Frames will go to Fifo0 when they do no match any specific filter
     IntoRxFifo0 = 0b00,
@@ -228,6 +235,7 @@ pub enum NonMatchingFilter {
 
 /// How to handle frames which do not match a specific filter
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct GlobalFilter {
     /// How to handle non-matching standard frames
     pub handle_standard_frames: NonMatchingFilter,
@@ -293,6 +301,7 @@ impl Default for GlobalFilter {
 
 /// FdCan Config Struct
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct FdCanConfig {
     /// Nominal Bit Timings
     pub nbtr: NominalBitTiming,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -106,6 +106,7 @@ impl ExtendedFilter {
 
 /// Filter Type
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum FilterType<ID, UNIT>
 where
     ID: Copy + Clone + core::fmt::Debug,
@@ -150,6 +151,7 @@ where
 
 /// Filter Action
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Action {
     /// No Action
     Disable = 0b000,
@@ -182,6 +184,7 @@ impl From<Action> for crate::message_ram::enums::FilterElementConfig {
 
 /// Filter
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Filter<ID, UNIT>
 where
     ID: Copy + Clone + core::fmt::Debug,
@@ -195,6 +198,7 @@ where
 
 /// Standard Filter Slot
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum StandardFilterSlot {
     /// 0
     _0 = 0,
@@ -291,6 +295,7 @@ impl From<u8> for StandardFilterSlot {
 
 /// Extended Filter Slot
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum ExtendedFilterSlot {
     /// 0
     _0 = 0,
@@ -327,6 +332,7 @@ impl From<u8> for ExtendedFilterSlot {
 
 /// Enum over both Standard and Extended Filter ID's
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum FilterId {
     /// Standard Filter Slots
     Standard(StandardFilterSlot),

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -13,6 +13,7 @@ use crate::message_ram::enums::{DataLength, FilterFrameMatch};
 
 /// Type of Frame
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum FrameFormat {
     /// Frame used by Classic CAN
     Standard = 0,
@@ -46,6 +47,7 @@ impl From<PacFrameFormat> for FrameFormat {
 /// This struct wraps the *arbitration field* and implements `PartialOrd` and `Ord` accordingly,
 /// ordering higher priorities greater than lower ones.
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct FramePriority(pub(crate) IdReg);
 
 /// Ordering is based on the Identifier and frame type (data vs. remote) and can be used to sort
@@ -72,6 +74,7 @@ impl Eq for FramePriority {}
 
 /// Header of a transmit request
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct TxFrameHeader {
     /// Length of the data in bytes
     pub len: u8,
@@ -139,6 +142,7 @@ impl From<&TxBufferElementHeader> for TxFrameHeader {
 
 /// Header of a Received Frame
 #[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct RxFrameInfo {
     /// Length in bytes
     pub len: u8,

--- a/src/id.rs
+++ b/src/id.rs
@@ -6,6 +6,7 @@ use crate::message_ram::enums::{IdType, RemoteTransmissionRequest};
 
 /// Standard 11-bit CAN Identifier (`0..=0x7FF`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct StandardId(u16);
 
 impl StandardId {
@@ -52,6 +53,7 @@ impl From<StandardId> for IdType {
 
 /// Extended 29-bit CAN Identifier (`0..=1FFF_FFFF`).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct ExtendedId(u32);
 
 impl ExtendedId {
@@ -105,6 +107,7 @@ impl From<ExtendedId> for IdType {
 
 /// A CAN Identifier (standard or extended).
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Id {
     /// Standard 11-bit Identifier (`0..=0x7FF`).
     Standard(StandardId),
@@ -148,6 +151,7 @@ impl From<Id> for IdType {
 /// have a higher priority than extended frames and data frames have a higher
 /// priority than remote frames.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub(crate) struct IdReg(u32);
 
 impl IdReg {

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -20,6 +20,7 @@ macro_rules! declare_interrupts {
         /// `[crate::config::FdCanConfig]` struct.
         #[derive(Debug, Copy, Clone, Eq, PartialEq)]
         #[non_exhaustive]
+        #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
         pub enum Interrupt {
             $(
                 #[doc = $doc]
@@ -30,6 +31,7 @@ macro_rules! declare_interrupts {
         paste::paste! {
             bitflags::bitflags! {
                 /// A set of FdCAN interrupts.
+                #[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
                 pub struct Interrupts: u32 {
                     $(
                         #[doc = $doc]
@@ -195,6 +197,7 @@ impl ops::BitOrAssign<Interrupt> for Interrupts {
 /// The events linked to these can be configured
 /// see `[config::FdCanConfig]`
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum InterruptLine {
     /// Interrupt Line 0
     _0 = 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub unsafe trait Instance: message_ram::Instance {
 
 /// Indicates if an Receive Overflow has occurred
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum ReceiveErrorOverflow {
     /// No overflow has occurred
     Normal(u8),
@@ -97,6 +98,7 @@ pub enum ReceiveErrorOverflow {
 ///Error Counters
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct ErrorCounters {
     /// General CAN error counter
     pub can_errors: u8,
@@ -116,6 +118,7 @@ enum LoopbackMode {
 
 /// Bus Activity
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Activity {
     /// Node is Synchronizing
     Synchronizing = 0b00,
@@ -141,6 +144,7 @@ impl TryFrom<u8> for Activity {
 
 /// Indicates the type of the last error which occurred on the CAN bus
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum LastErrorCode {
     /// There has been no error since last read
     NoError = 0b000,
@@ -179,6 +183,7 @@ impl TryFrom<u8> for LastErrorCode {
 /// Some status indications regarding the FDCAN protocl
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct ProtocolStatus {
     /// Type of current activity
     pub activity: Activity,
@@ -200,13 +205,16 @@ pub trait Transmit {}
 pub trait Receive {}
 
 /// Allows for the FdCan Instance to be released or to enter ConfigMode
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct PoweredDownMode;
 /// Allows for the configuration for the Instance
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct ConfigMode;
 /// This mode can be used for a “Hot Selftest”, meaning the FDCAN can be tested without
 /// affecting a running CAN system connected to the FDCAN_TX and FDCAN_RX pins. In this
 /// mode, FDCAN_RX pin is disconnected from the FDCAN and FDCAN_TX pin is held
 /// recessive.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct InternalLoopbackMode;
 impl Transmit for InternalLoopbackMode {}
 impl Receive for InternalLoopbackMode {}
@@ -216,10 +224,12 @@ impl Receive for InternalLoopbackMode {}
 /// feedback from its transmit output to its receive input. The actual value of the FDCAN_RX
 /// input pin is disregarded by the FDCAN. The transmitted messages can be monitored at the
 /// FDCAN_TX transmit pin.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct ExternalLoopbackMode;
 impl Transmit for ExternalLoopbackMode {}
 impl Receive for ExternalLoopbackMode {}
 /// The normal use of the FdCan instance after configurations
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct NormalOperationMode;
 impl Transmit for NormalOperationMode {}
 impl Receive for NormalOperationMode {}
@@ -229,6 +239,7 @@ impl Receive for NormalOperationMode {}
 /// send dominant bits, instead it waits for the occurrence of bus idle condition to resynchronize
 /// itself to the CAN communication. The error counters for transmit and receive are frozen while
 /// error logging (can_errors) is active. TODO: automatically enter in this mode?
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct RestrictedOperationMode;
 impl Receive for RestrictedOperationMode {}
 ///  In Bus monitoring mode (for more details refer to ISO11898-1, 10.12 Bus monitoring),
@@ -239,14 +250,17 @@ impl Receive for RestrictedOperationMode {}
 /// state. In Bus monitoring mode the TXBRP register is held in reset state. The Bus monitoring
 /// mode can be used to analyze the traffic on a CAN bus without affecting it by the transmission
 /// of dominant bits.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct BusMonitoringMode;
 impl Receive for BusMonitoringMode {}
 /// Test mode must be used for production tests or self test only. The software control for
 /// FDCAN_TX pin interferes with all CAN protocol functions. It is not recommended to use test
 /// modes for application.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct TestMode;
 
 /// Interface to a FdCAN peripheral.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct FdCan<I: Instance, MODE> {
     control: FdCanControl<I, MODE>,
 }
@@ -1120,6 +1134,7 @@ where
 /// FdCanControl Struct
 /// Used to house some information during an FdCan split.
 /// and can be used for some generic information retrieval during operation.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct FdCanControl<I, MODE>
 where
     I: Instance,
@@ -1185,6 +1200,7 @@ where
 }
 
 /// Interface to the CAN transmitter part.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Tx<I, MODE> {
     _can: PhantomData<I>,
     _mode: PhantomData<MODE>,
@@ -1460,6 +1476,7 @@ impl FifoNr for Fifo1 {
 /// Notes whether an overrun has occurred.
 /// Since both arms contain T, this can be 'unwrap'ed without causing a panic.
 #[derive(Clone, Copy, Debug)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum ReceiveOverrun<T> {
     /// No overrun has occured
     NoOverrun(T),
@@ -1479,6 +1496,7 @@ impl<T> ReceiveOverrun<T> {
 }
 
 /// Interface to the CAN receiver part.
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub struct Rx<I, MODE, FIFONR>
 where
     FIFONR: FifoNr,
@@ -1618,6 +1636,7 @@ where
 /// These are used for the transmit queue
 /// and the two Receive FIFOs
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt-03", derive(defmt::Format))]
 pub enum Mailbox {
     /// Transmit mailbox 0
     _0 = 0,


### PR DESCRIPTION
This adds optional defmt format derives to the relevant structs and enums gated with the `defmt-03` feature.