### PR TITLE
Tx: make abort() function public.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1386,7 +1386,7 @@ where
     /// If there is a frame in the provided mailbox, and it is canceled successfully, this function
     /// returns `true`.
     #[inline]
-    fn abort(&mut self, idx: Mailbox) -> bool {
+    pub fn abort(&mut self, idx: Mailbox) -> bool {
         let can = self.registers();
 
         // Check if there is a request pending to abort


### PR DESCRIPTION
Allows access to abort function after splitting the driver. The equivalent function in `FdCan<I, M>` is already public, so I think this is safe.

Thanks for all your work developing fdcan, it's much appreciated!