### PR TITLE
frame: Implement From<Id> for FramePriority

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,5 +1,6 @@
 use core::cmp::Ordering;
 
+use crate::id::{StandardId, ExtendedId};
 use crate::Id;
 use crate::IdReg;
 
@@ -47,6 +48,24 @@ impl From<PacFrameFormat> for FrameFormat {
 /// ordering higher priorities greater than lower ones.
 #[derive(Debug, Copy, Clone)]
 pub struct FramePriority(pub(crate) IdReg);
+
+impl From<Id> for FramePriority {
+    fn from(value: Id) -> Self {
+        Self(value.into())
+    }
+}
+
+impl From<StandardId> for FramePriority {
+    fn from(value: StandardId) -> Self {
+        Id::Standard(value).into()
+    }
+}
+
+impl From<ExtendedId> for FramePriority {
+    fn from(value: ExtendedId) -> Self {
+        Id::Extended(value).into()
+    }
+}
 
 /// Ordering is based on the Identifier and frame type (data vs. remote) and can be used to sort
 /// frames by priority.


### PR DESCRIPTION
The `FramePriority` struct is a public struct that's potentially very useful for fdcan users, but there's not currently a way to obtain a `FramePriority` outside the driver crate.

Hence, this PR implements `From<Id>` for `FramePriority`, plus `From<StandardId>` and `From<ExtendedId>` for convenience.
