### PR TITLE
Implement transceiver delay compensation configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update MSRV to 1.60
 * Allow timestamp to be accessed in all modes
+* Implement transceiver delay compensation configuration
 
 ## [v0.2.1] 2024-09-04
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,12 +78,10 @@ pub struct DataBitTiming {
     pub sync_jump_width: NonZeroU8,
 }
 impl DataBitTiming {
-    // #[inline]
-    // fn tdc(&self) -> u8 {
-    //     let tsd = self.transceiver_delay_compensation as u8;
-    //     //TODO: stm32g4 does not export the TDC field
-    //     todo!()
-    // }
+    #[inline]
+    pub(crate) fn tdc(&self) -> bool {
+        self.transceiver_delay_compensation
+    }
     #[inline]
     pub(crate) fn dbrp(&self) -> u8 {
         u8::from(self.prescaler) & 0x1F

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,7 +756,8 @@ where
 
         let can = self.registers();
         if btr.tdc() {
-            let tcdo = btr.dtseg1() * btr.dbrp();
+            let tcdo = btr.dtseg1().saturating_mul(btr.dbrp());
+            let tcdo = core::cmp::min(tcdo, 127);
             can.tdcr.write(|w| unsafe { w.tdco().bits(tcdo) });
         }
         can.dbtp.write(|w| unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -755,6 +755,10 @@ where
         self.control.config.dbtr = btr;
 
         let can = self.registers();
+        if btr.tdc() {
+            let tcdo = btr.dtseg1() * btr.dbrp();
+            can.tdcr.write(|w| unsafe { w.tdco().bits(tcdo) });
+        }
         can.dbtp.write(|w| unsafe {
             w.dbrp()
                 .bits(btr.dbrp() - 1)
@@ -764,6 +768,8 @@ where
                 .bits(btr.dtseg2() - 1)
                 .dsjw()
                 .bits(btr.dsjw() - 1)
+                .tdc()
+                .bit(btr.tdc())
         });
     }
 


### PR DESCRIPTION
Tested on an STM32G474, working up to 10 Mbit/s. Without this, the controller won't ack any frames above 3 Mbit/s.