### PR TITLE
Allow timestamp to be accessed from all modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Update MSRV to 1.60
+* Allow timestamp to be accessed in all modes
 
 ## [v0.2.1] 2024-09-04
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -542,6 +542,12 @@ where
     ) -> Self {
         Self::create_can(t.0.config, t.0.instance)
     }
+
+    /// Returns the current FdCan timestamp counter
+    #[inline]
+    pub fn timestamp(&self) -> u16 {
+        self.control.timestamp()
+    }
 }
 
 impl<I> FdCan<I, PoweredDownMode>
@@ -881,12 +887,6 @@ where
             .rrfe()
             .bit(filter.reject_remote_extended_frames)
         });
-    }
-
-    /// Returns the current FdCan timestamp counter
-    #[inline]
-    pub fn timestamp(&self) -> u16 {
-        self.control.timestamp()
     }
 }
 


### PR DESCRIPTION
Currently the timestamp can only be accessed in config mode.