### PR TITLE
Fix global filter not saving

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -887,6 +887,8 @@ where
             .rrfe()
             .bit(filter.reject_remote_extended_frames)
         });
+
+        self.control.config.global_filter = filter;
     }
 }
 


### PR DESCRIPTION
The global filter settings were being overwritten upon subsequent changes to the can config object